### PR TITLE
Ersetze lat-lon Paar durch GIS Point

### DIFF
--- a/t30.php
+++ b/t30.php
@@ -70,8 +70,7 @@ class Institution extends IdEntity {
             ['name' => 'number', 'type' => 'varchar', 'length' => 8],
             ['name' => 'zip', 'type' => 'varchar', 'length' => 5],
             ['name' => 'district', 'type' => 'varchar', 'length' => 64, 'notNull' => false],
-            ['name' => 'lat', 'type' => 'decimal', 'length' => '8,6'],
-            ['name' => 'lon', 'type' => 'decimal', 'length' => '8,6'],
+            ['name' => 'position', 'type' => 'point']
         ]);
     }
 


### PR DESCRIPTION
Die 2 Felder 'lat' und 'lon' der Entität 'institution' wird durch ein Feld 'position' mit Typ 'point' ersetzt. 

Create geht dann so:

POST
```json
{
	"name": "ABC-Schule",
	"type": 1,
	"street_house_no": "Schulstr. 1",
	"zip": "21077",
	"city": "Hamburg",
	"position": [53.438028, 9.98145]
}
```
