### PR TITLE
Fix: Eigene User-Daten jetzt lesbar

### DIFF
--- a/api.php
+++ b/api.php
@@ -58,6 +58,7 @@ FlexApi::onSetup(function($request) {
     FlexAPI::guard()->allowCRUD('guest', 'cRud', 'policedepartment', false);
     FlexAPI::guard()->allowCRUD('guest', 'cRud', 'demandedstreetsection', false);
 
+    FlexAPI::guard()->allowCRUD('registered', 'CRUd', 'userdata', true);
     FlexAPI::guard()->allowCRUD('registered', 'CRUd', 'institution', false);
     FlexAPI::guard()->allowCRUD('registered', 'CRUd', 'demandedstreetsection', false);
 
@@ -97,8 +98,8 @@ FlexApi::onSetup(function($request) {
             'zip' => 22666
         ];
         FlexAPI::guard()->registerUser($username, $password , false);
-        FlexAPI::superAccess()->insert('userdata', $userData);
-        FlexAPI::guard()->publishResource($username, 'userdata', $username , 'RU');
+        $id = FlexAPI::superAccess()->insert('userdata', $userData);
+        FlexAPI::guard()->publishResource($username, 'userdata', $id , 'RU');
         FlexAPI::guard()->assignRole('guest', $username);
         FlexAPI::guard()->assignRole('registered', $username);
     }
@@ -136,8 +137,8 @@ FlexAPI::onEvent('after-user-registration', function($event) {
     $userData = (array) $event['request']['userData'];
     $username = $event['request']['username'];
     $userData['user'] = $username;
-    FlexAPI::superAccess()->insert('userdata', $userData);
-    FlexAPI::guard()->publishResource($username, 'userdata', $username , 'RU');
+    $id = FlexAPI::superAccess()->insert('userdata', $userData);
+    FlexAPI::guard()->publishResource($username, 'userdata', $id , 'RU');
 });
 
 FlexAPI::onEvent('after-user-verification', function($event) {


### PR DESCRIPTION
Lesen der eigenen User-Daten sollte jetzt funkionieren:

GET /crud.php?entity=userdata&flatten=singleResult

ergibt:
``` json
{
    "id": 1,
    "user": "max-muster@some-provider.de",
    "street_house_no": "Fakestreet 123",
    "zip": "22666",
    "city": "Hamburg",
    "phone": null,
    "mobile": null
}
```