### PR TITLE
Email-Adresse (= Benutzername) ändern

### DIFF
--- a/api.php
+++ b/api.php
@@ -232,6 +232,16 @@ FlexAPI::onEvent('after-user-verification', function($event) {
     // }
 });
 
+FlexAPI::onEvent('after-email-change', function($event) {
+    if ($event['result']['emailChangeSuccessfull']) {
+        $userData = FlexAPI::superAccess()->read('userdata', [
+            'filter' => ['user' => $event['result']['oldEmail']],
+            'flatten' => 'singleResult'
+        ]);
+        $userData['user'] = $event['result']['newEmail'];
+        FlexAPI::superAccess()->update('userdata', $userData);
+    }
+});
 
 FlexAPI::onEvent('before-user-unregistration', function($event) {
     if (in_array($event['username'], ['admin', 'guest'])) {


### PR DESCRIPTION
Da die Email bei uns auch gleichzeitig der Benutzername ist, ist das Verfahren ein bisschen kompliziert. Dafür gibt es 2 neue Requests (man muss jeweils angemeldet sein).

1. Änderungs-Antrag:
POST /api/portal.php
``` json
{
	"concern": "emailChange",
	"newEmail": "neue@adresse.de"
}
```
Es wird ein neuer Benutzer "neue@adresse.de" angelegt mit dem alten Passwort. An die neue Adresse wird ein Token (z.b. AAABBB) geschickt.

2. Änderung umsetzen:
POST /api/portal.php
``` json
{
	"concern": "emailChange",
	"token": "AAABBB",
	"user": "neue@adresse.de"
}
```
Die alten Nutzerdaten werden auf die neue Adresse umgeschrieben. Der bisherige User wird gelöscht, weshalb danach ein Neu-Einlogen mit der neuen Email nötig ist.
